### PR TITLE
Fix nsqlookupd instances not being able to talk

### DIFF
--- a/vagrant/cookbooks/servo-nsq/metadata.rb
+++ b/vagrant/cookbooks/servo-nsq/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email 'john@dewey.ws'
 license 'Apache 2.0'
 description 'Wrapper cookbook for setting up NSQ'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.0.0'
+version '1.0.1'
 
 depends 'nsq'

--- a/vagrant/cookbooks/servo-nsq/recipes/default.rb
+++ b/vagrant/cookbooks/servo-nsq/recipes/default.rb
@@ -22,8 +22,9 @@ Chef::Recipe.send(:include, ServoNSQ::Helpers)
 
 address = address_for node['servo-nsq']['bind_interface']
 
-node.set['nsq']['nsqd']['broadcast_address'] = address
-node.set['nsq']['nsqlookupd']['broadcast_address'] = address
+node.override['nsq']['nsqd']['broadcast_address'] = address
+node.override['nsq']['nsqlookupd']['broadcast_address'] = address
+node.override['nsq']['nsqlookupd']['tcp_address'] = "#{address}:4160"
 
 include_recipe 'nsq::nsqadmin'
 include_recipe 'nsq::nsqd'


### PR DESCRIPTION
For some reason it doesn't seem to bind on all interfaces, only if
you specify a specific IP.
