### PR TITLE
Various cleanups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,6 @@
 all: deps
 
 deps:
-	git submodule init
-	git submodule update
-	go get -d -v ./...
-
-test: deps
-	go list ./... | xargs -n1 go test
+	git submodule update --init
 
 .PNONY: all deps test

--- a/vagrant/cookbooks/servo-nsq/attributes/default.rb
+++ b/vagrant/cookbooks/servo-nsq/attributes/default.rb
@@ -18,4 +18,4 @@
 # limitations under the License.
 #
 
-default['servo-nsq']['bind_interface'] = 'eth1'
+default['servo-nsq']['broadcast_interface'] = 'eth1'

--- a/vagrant/cookbooks/servo-nsq/metadata.rb
+++ b/vagrant/cookbooks/servo-nsq/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email 'john@dewey.ws'
 license 'Apache 2.0'
 description 'Wrapper cookbook for setting up NSQ'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.0.1'
+version '1.0.2'
 
 depends 'nsq'

--- a/vagrant/cookbooks/servo-nsq/recipes/default.rb
+++ b/vagrant/cookbooks/servo-nsq/recipes/default.rb
@@ -20,11 +20,10 @@
 
 Chef::Recipe.send(:include, ServoNSQ::Helpers)
 
-address = address_for node['servo-nsq']['bind_interface']
+address = address_for node['servo-nsq']['broadcast_interface']
 
 node.override['nsq']['nsqd']['broadcast_address'] = address
 node.override['nsq']['nsqlookupd']['broadcast_address'] = address
-node.override['nsq']['nsqlookupd']['tcp_address'] = "#{address}:4160"
 
 include_recipe 'nsq::nsqadmin'
 include_recipe 'nsq::nsqd'


### PR DESCRIPTION
- Remove obsolete golang stuff
- Revert override of nsqd tcp address.  Seemed to be an issue
  specific to virtualbox 4.3.10.
- Change attribute name to better reflect what we use it for.
